### PR TITLE
Get products by a location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -104,6 +104,7 @@ class Products(ViewSet):
 
             new_product.image_path = data
 
+        new_product.clean_fields()
         new_product.save()
 
         serializer = ProductSerializer(
@@ -253,6 +254,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
+        # location = self.reqest.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -279,6 +281,9 @@ class Products(ViewSet):
             
         if min_price is not None:
             products = products.filter(price__gte = min_price)    
+            
+        # if location is not None:
+        #     products = products.filter(location__contains = location)    
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -254,7 +254,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
-        # location = self.reqest.query_params.get('location', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -282,8 +282,8 @@ class Products(ViewSet):
         if min_price is not None:
             products = products.filter(price__gte = min_price)    
             
-        # if location is not None:
-        #     products = products.filter(location__contains = location)    
+        if location is not None:
+            products = products.filter(location__contains = location)    
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Modified /views/product.py to add a location parameter so that when a user is searching for product by location, products with the location name matching the searched location will be returned.


## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

## Testing

Description of how to test code...

Test in postman:
http://localhost:8000/products?location=Onguday

```
git fetch —all
git checkout yc-productbylocation
serve

```
## Related Issues

- Fixes #14 